### PR TITLE
Refactor Docker image build workflow to support multi-architecture

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -36,43 +36,102 @@ jobs:
         run: |
           docker build -t mcp_server_ros_2  --build-arg ROS_DISTRO=${{ matrix.ros_distro }} .
 
-  build_and_push_image:
+  build_and_push_arm64:
     if: github.event_name == 'push'
+    name: Build & Push (ARM64)
     runs-on: wisevision-runner
     strategy:
       matrix:
         ros_distro: [humble, jazzy]
-    container:
-      image: ubuntu:22.04
-    
+
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
-      
+        uses: actions/checkout@v4
+
       - name: Install Docker CLI
         run: |
           apt-get update
           apt-get install -y docker.io
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build & push ARM64 image
+        run: |
+          docker buildx build \
+            --platform linux/arm64 \
+            --file Dockerfile \
+            --build-arg ROS_DISTRO=${{ matrix.ros_distro }} \
+            --tag ${{ secrets.DOCKER_HUB_USERNAME }}/mcp_server_ros_2:${{ matrix.ros_distro }}-arm64 \
+            --push \
+            .
+
+  build_and_push_amd64:
+    if: github.event_name == 'push'
+    name: Build & Push (AMD64)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ros_distro: [humble, jazzy]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
         with:
-          platforms: all
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
-      - name: Build and push Docker image for multiple architectures
+      - name: Build & push AMD64 image
         run: |
-          docker buildx build --platform linux/amd64,linux/arm64 \
-          --file Dockerfile \
-          --build-arg ROS_DISTRO=${{ matrix.ros_distro }} \
-          --tag ${{ secrets.DOCKER_HUB_USERNAME }}/mcp_server_ros_2:${{ matrix.ros_distro }} \
-          --push \
-          .
+          docker buildx build \
+            --platform linux/amd64 \
+            --file Dockerfile \
+            --build-arg ROS_DISTRO=${{ matrix.ros_distro }} \
+            --tag ${{ secrets.DOCKER_HUB_USERNAME }}/mcp_server_ros_2:${{ matrix.ros_distro }}-amd64 \
+            --push \
+            .
+
+  merge_manifests:
+    if: github.event_name == 'push'
+    name: Merge Images into Multi-Arch (Docker Hub)
+    runs-on: wisevision-runner
+    needs: [build_and_push_arm64, build_and_push_amd64]
+    strategy:
+      matrix:
+        ros_distro: [humble, jazzy]
+
+    steps:
+      - name: Install Docker CLI
+        run: |
+          apt-get update
+          apt-get install -y docker.io
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Merge ARM64 and AMD64 into one multi-arch tag (Docker Hub)
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ secrets.DOCKER_HUB_USERNAME }}/mcp_server_ros_2:${{ matrix.ros_distro }} \
+            ${{ secrets.DOCKER_HUB_USERNAME }}/mcp_server_ros_2:${{ matrix.ros_distro }}-amd64 \
+            ${{ secrets.DOCKER_HUB_USERNAME }}/mcp_server_ros_2:${{ matrix.ros_distro }}-arm64
+
+          docker buildx imagetools inspect ${{ secrets.DOCKER_HUB_USERNAME }}/mcp_server_ros_2:${{ matrix.ros_distro }}


### PR DESCRIPTION
This pull request refactors the Docker image build workflow to improve multi-architecture support and streamline the build and deployment process. The workflow now builds and pushes ARM64 and AMD64 images separately, then merges them into a single multi-architecture manifest on Docker Hub. Key updates also include upgrading GitHub Actions and Docker-related actions for better reliability and maintainability.

**Multi-architecture build and deployment:**

* Split the build process into two separate jobs: `build_and_push_arm64` (runs on ARM64 runner) and `build_and_push_amd64` (runs on AMD64 runner), each building and pushing architecture-specific images with distinct tags. (`.github/workflows/docker_image.yml`)
* Added a new `merge_manifests` job that merges the ARM64 and AMD64 images into a single multi-arch Docker tag using `docker buildx imagetools`, ensuring users can pull the correct image for their platform. (`.github/workflows/docker_image.yml`)

**Action and tooling upgrades:**

* Updated all relevant GitHub Actions to their latest major versions (`actions/checkout@v4`, `docker/login-action@v3`, `docker/setup-buildx-action@v3`) for improved performance and security. (`.github/workflows/docker_image.yml`)
