### PR TITLE
Add container specification for ARM64

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -43,6 +43,8 @@ jobs:
     strategy:
       matrix:
         ros_distro: [humble, jazzy]
+    container:
+      image: ubuntu:22.04
 
     steps:
       - name: Checkout repository
@@ -111,6 +113,8 @@ jobs:
     strategy:
       matrix:
         ros_distro: [humble, jazzy]
+    container:
+      image: ubuntu:22.04
 
     steps:
       - name: Install Docker CLI


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow for building Docker images. The main change is the addition of a `container` specification to run the workflow steps inside an `ubuntu:22.04` container environment.

* Workflow environment update:
  * Added a `container` section with `image: ubuntu:22.04` to both jobs in `.github/workflows/docker_image.yml`, ensuring that all steps run inside a consistent Ubuntu 22.04 container. [[1]](diffhunk://#diff-e0ed06ed167d42ded61bb8913c0f02d8a691900a916546329d70b7ae1a14e994R46-R47) [[2]](diffhunk://#diff-e0ed06ed167d42ded61bb8913c0f02d8a691900a916546329d70b7ae1a14e994R116-R117)