### PR TITLE
Switch default ROS distribution  to jazzy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG ROS_DISTRO=humble
+ARG ROS_DISTRO=jazzy
 FROM wisevision/ros_with_wisevision_msgs_and_wisevision_core:${ROS_DISTRO}
 
 RUN apt-get update && apt-get install -y \

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Set MCP setting to mcp.json.
         "run",
         "-i",
         "--rm",
-        "wisevision/mcp_server_ros_2"
+        "wisevision/mcp_server_ros_2:<humble/jazzy>"
     ],
     }
 
@@ -76,7 +76,7 @@ Set MCP setting to mcp.json.
 ```bash
 git clone https://github.com/wise-vision/mcp_server_ros_2.git
 cd mcp_server_ros_2
-docker build -t wisevision/mcp_server_ros_2 .
+docker build -t mcp_server_ros_2:<humble/jazzy>  --build-arg ROS_DISTRO=<humble/jazzy> .
 ```
 
 


### PR DESCRIPTION
This pull request updates the project to support the newer ROS 2 Jazzy distribution, replacing the previous default of Humble. It also updates documentation to reflect the new ROS distribution and image naming conventions.

**ROS Distribution Update:**

* Changed the default ROS distribution from `humble` to `jazzy` in the `Dockerfile`, ensuring the build uses the latest ROS 2 release.

**Documentation Updates:**

* Updated the Docker image tag in the `README.md` to use `<humble/jazzy>`, reflecting the new convention for specifying the ROS distribution in image names.
* Modified the build instructions in the `README.md` to show how to build the Docker image with a specific ROS distribution using the `--build-arg ROS_DISTRO=<humble/jazzy>` flag and the new image tag format.