### PR TITLE
Add QoS profile handling for publisher topics

### DIFF
--- a/server/ros2_manager.py
+++ b/server/ros2_manager.py
@@ -323,7 +323,10 @@ class ROS2Manager:
         tmp_node = Node("mcp_subscribe_tmp")
         received = []
         done_future = Future()
-        qos = self.get_qos_profile_for_topic(tmp_node, topic_name)
+        try:
+            qos = self.get_qos_profile_for_topic(tmp_node, topic_name)
+        finally:
+            tmp_node.destroy_node()
 
         def callback(msg):
             received.append(msg)
@@ -453,7 +456,10 @@ class ROS2Manager:
             return {"error": f"Failed to load message type: {str(e)}"}
         
         tmp_node = Node("mcp_publish_tmp")
-        qos = self.get_qos_for_publisher_topic(tmp_node, topic_name)
+        try:
+            qos = self.get_qos_for_publisher_topic(tmp_node, topic_name)
+        finally:
+            tmp_node.destroy_node()
 
         try:
             pub = self.node.create_publisher(msg_class, topic_name, qos)

--- a/server/tools_ros2.py
+++ b/server/tools_ros2.py
@@ -211,12 +211,14 @@ class ROS2TopicSubscribe(toolhandler.ToolHandler):
 # Legacy support for wisevision_data_black_box
 class ROS2GetMessages(toolhandler.ToolHandler):
     def __init__(self):
-        super().__init__("ros2_get_messages")
+        super().__init__("ros2_get_messages_stored_in_influx_data_base")
 
     def get_tool_description(self):
         return Tool(
             name=self.name,
-            description="""Calls the ROS2 ‘/get_messages’ service to retrieve past messages from a topic for data which is stored in InfluxDB.""",
+            description="""Calls the ROS2 ‘/get_messages’ service to retrieve past messages from a topic for data which is stored in InfluxDB.
+            Check if the /get_messages service is available before calling.
+            """,
             inputSchema={
                 "type": "object",
                 "properties": {

--- a/tests/ros2_manager_test.py
+++ b/tests/ros2_manager_test.py
@@ -403,7 +403,6 @@ from rclpy.qos import (
     QoSDurabilityPolicy,
     QoSHistoryPolicy,
 )
-from rclpy.qos import QoSProfile, QoSReliabilityPolicy, QoSDurabilityPolicy, QoSHistoryPolicy
 from rclpy.executors import SingleThreadedExecutor
 from std_msgs.msg import String
 import time


### PR DESCRIPTION
This pull request introduces a more robust mechanism for selecting the Quality of Service (QoS) profile when publishing messages to ROS 2 topics. The main improvement is that the publisher now chooses a QoS profile that is compatible with all active subscribers on a topic, ensuring better reliability and compatibility. The changes also include new tests to verify this logic.

**QoS Profile Selection Improvements**

* Added a new method `get_qos_for_publisher_topic` in `ros2_manager.py` that inspects all subscriptions to a topic and selects a superset QoS profile for publishers, taking into account reliability, durability, history, and depth settings.
* Updated the `publish_to_topic` method to use the selected QoS profile instead of a fixed value, ensuring that published messages are compatible with all current subscribers.

**Testing Enhancements**

* Added an integration test `test_get_qos_for_publisher_topic_superset_real_subs` to verify that the QoS selection logic correctly chooses the superset profile when multiple subscribers with different profiles exist.
* Added a unit test `test_publish_to_topic_uses_selected_qos` to ensure that the publisher uses the QoS profile returned by the new selection method.

**Codebase Maintenance**

* Refactored QoS-related imports for clarity and completeness in `ros2_manager.py` and test files.