### PR TITLE
Add volume for custom ROS messages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,28 +2,28 @@ ARG ROS_DISTRO=jazzy
 FROM wisevision/ros_with_wisevision_msgs_and_wisevision_core:${ROS_DISTRO}
 
 RUN apt-get update && apt-get install -y \
-    python3-pip \
-    build-essential \
-    ca-certificates \
-    ros-${ROS_DISTRO}-std-msgs \
-    ros-${ROS_DISTRO}-geometry-msgs \
-    ros-${ROS_DISTRO}-sensor-msgs \
-    ros-${ROS_DISTRO}-nav-msgs \
-    ros-${ROS_DISTRO}-action-msgs \
-    ros-${ROS_DISTRO}-diagnostic-msgs \
-    ros-${ROS_DISTRO}-trajectory-msgs \
-    ros-${ROS_DISTRO}-visualization-msgs \
-    ros-${ROS_DISTRO}-example-interfaces \
-    ros-${ROS_DISTRO}-rclpy \
-    ros-${ROS_DISTRO}-ros2cli \
-    python3-colcon-common-extensions \
-    && rm -rf /var/lib/apt/lists/*
+  python3-pip \
+  build-essential \
+  ca-certificates \
+  ros-${ROS_DISTRO}-std-msgs \
+  ros-${ROS_DISTRO}-geometry-msgs \
+  ros-${ROS_DISTRO}-sensor-msgs \
+  ros-${ROS_DISTRO}-nav-msgs \
+  ros-${ROS_DISTRO}-action-msgs \
+  ros-${ROS_DISTRO}-diagnostic-msgs \
+  ros-${ROS_DISTRO}-trajectory-msgs \
+  ros-${ROS_DISTRO}-visualization-msgs \
+  ros-${ROS_DISTRO}-example-interfaces \
+  ros-${ROS_DISTRO}-rclpy \
+  ros-${ROS_DISTRO}-ros2cli \
+  python3-colcon-common-extensions \
+  && rm -rf /var/lib/apt/lists/*
 
 RUN if [ "$ROS_DISTRO" = "humble" ]; then \
-      pip install uv; \
-    elif [ "$ROS_DISTRO" = "jazzy" ]; then \
-      pip install uv --break-system-packages; \
-    fi
+  pip install uv; \
+  elif [ "$ROS_DISTRO" = "jazzy" ]; then \
+  pip install uv --break-system-packages; \
+  fi
 
 WORKDIR /app
 COPY . /app
@@ -31,10 +31,21 @@ COPY . /app
 RUN uv venv
 
 RUN if [ "$ROS_DISTRO" = "jazzy" ]; then \
-      uv python pin 3.12; \
-    fi
+  uv python pin 3.12; \
+  fi
 
 RUN uv sync
 
+RUN mkdir -p /mcp/custom_msgs
+VOLUME ["/mcp/custom_msgs"]
+
 ENTRYPOINT []
-CMD ["bash", "-c", "source /opt/ros/${ROS_DISTRO}/setup.bash && source /root/wisevision_ws/install/setup.bash && source .venv/bin/activate && uv run mcp_ros_2_server"]
+CMD ["bash", "-c", " \
+  source /opt/ros/${ROS_DISTRO}/setup.bash && \
+  source /root/wisevision_ws/install/setup.bash && \
+  source .venv/bin/activate && \
+  if [ -f /app/custom_msgs/install/setup.bash ]; then \
+  source /app/custom_msgs/install/setup.bash; \
+  fi && \
+  uv run mcp_ros_2_server \
+  "]

--- a/installation/README.md
+++ b/installation/README.md
@@ -42,7 +42,7 @@ Before you begin, ensure you have the following:
 3. Click on the `Edit config` in `local MCP servers`.
 
 ![Enter image name](../docs/assets/claude_add_mcp.png)
-4. Paste it into this config:
+4. Paste it into config:
 ```json
 {
   "mcp_server_ros_2": {
@@ -59,7 +59,24 @@ Before you begin, ensure you have the following:
   }
 }
 ```
-
+To use custom messages [create folder](#add-custom-messages) and paste it into config:
+```json
+{
+  "mcp_server_ros_2": {
+    "command": "docker",
+    "args": [
+      "run",
+      "-i",
+      "--rm",
+      "-v", "~/mcp_custom_messages:/app/custom_msgs"
+      "wisevision/mcp_server_ros_2:<humble/jazzy>"
+    ],
+    "env": {},
+    "working_directory": null,
+    "start_on_launch": true
+  }
+}
+```
 ### Step 2: Save and Enjoy
 
 After saving you should see indicator that the MCP server is running.
@@ -114,6 +131,24 @@ docker build -t wisevision/mcp_server_ros_2 .
   }
 }
 ```
+To use custom messages [create folder](#add-custom-messages) and paste it into config:
+```json
+{
+  "mcp_server_ros_2": {
+    "command": "docker",
+    "args": [
+      "run",
+      "-i",
+      "--rm",
+      "-v", "~/mcp_custom_messages:/app/custom_msgs"
+      "wisevision/mcp_server_ros_2:<humble/jazzy>"
+    ],
+    "env": {},
+    "working_directory": null,
+    "start_on_launch": true
+  }
+}
+```
 
 ### Step 4: Save and Enjoy
 
@@ -130,3 +165,19 @@ docker build -t mcp_server_ros_2:<humble/jazzy>  --build-arg ROS_DISTRO=<humble/
 
 ### Thanks for using our MCP server for ROS 2! Good luck with your projects!
 ---
+
+## Add custom messages
+### Create folder for custom messages
+```bash
+mkdir -p ~/mcp_custom_messages/src
+```
+### Add messages package to `src` in `mcp_custom_messages`
+```bash
+cd ~/mcp_custom_messages/src
+git clone https://github.com/ros/ros_tutorials.git #or your custom meesage pack
+```
+### Build
+```bash
+cd ~/mcp_custom_messages
+colcon build
+```


### PR DESCRIPTION
This pull request adds support for using custom ROS 2 message packages with the MCP server. The main changes include updates to the `Dockerfile` to mount a custom messages volume and conditionally source its setup script, as well as updates to the installation documentation to guide users through configuring and building custom message packages.

**Dockerfile and container setup improvements:**

* Added creation of the `/mcp/custom_msgs` directory and mounted it as a volume to allow injection of custom message packages at runtime.
* Updated the container startup command to source the custom messages setup script if it exists, ensuring custom message types are available to the MCP server.

**Documentation updates for custom messages:**

* Added instructions in `installation/README.md` for configuring the MCP server to use custom messages by mounting a host directory to `/app/custom_msgs` in the container. [[1]](diffhunk://#diff-44000acc45c449295a0026fa7c0a186036e322db06010ed69fbd75a816a8b53dL62-R79) [[2]](diffhunk://#diff-44000acc45c449295a0026fa7c0a186036e322db06010ed69fbd75a816a8b53dR134-R151)
* Provided a new section in the documentation detailing how to create, clone, and build a custom messages package using `colcon`.
* Minor wording update for clarity in the configuration instructions.