### PR TITLE
Add sever do MCP Registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 ARG ROS_DISTRO=jazzy
 FROM wisevision/ros_with_wisevision_msgs_and_wisevision_core:${ROS_DISTRO}
 
+LABEL io.modelcontextprotocol.server.name="io.github.wise-vision/mcp_server_ros_2"
+
 RUN apt-get update && apt-get install -y \
     python3-pip \
     build-essential \

--- a/server.json
+++ b/server.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "name": "io.github.wise-vision/mcp_server_ros_2",
+  "description": "View ROS 2 nodes and topics, and call services and actions via MCP",
+  "repository": {
+    "url": "https://github.com/wise-vision/mcp_server_ros_2",
+    "source": "github"
+  },
+  "version": "1.0.0",
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "docker.io/mcp/ros2:latest",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This pull request introduces metadata and documentation improvements for the ROS 2 MCP server. The key changes are the addition of a server metadata file and a descriptive label in the Docker image, which help with discoverability and integration with Model Context Protocol (MCP) tooling.

Metadata and documentation:

* Added a new `server.json` file describing the MCP ROS 2 server, including its name, description, repository, version, and package information for OCI registry integration.
* Added a `LABEL` to the `Dockerfile` to identify the server image with its MCP name, improving container metadata and discoverability.