### PR TITLE
Enhanced ROS2TopicPublish

### DIFF
--- a/server/tools_ros2.py
+++ b/server/tools_ros2.py
@@ -350,6 +350,7 @@ class ROS2TopicPublish(toolhandler.ToolHandler):
         return Tool(
             name=self.name,
             description="""Publish a message to a ROS 2 topic by name and message type using provided field values.
+            Supports single publish (default) or continuous publishing at a specified frequency for a duration.
             Before **every** use of this tool, the agent must call 'ros2_topic_list' and 'ros2_interface_list'
             to ensure the latest available topics and message types are known.""",
             inputSchema={
@@ -367,6 +368,14 @@ class ROS2TopicPublish(toolhandler.ToolHandler):
                         "type": "object",
                         "description": "Dictionary containing the message fields and values",
                     },
+                    "frequency": {
+                        "type": "number",
+                        "description": "Optional: Publish frequency in Hz (messages per second). If provided with duration, publishes repeatedly.",
+                    },
+                    "duration": {
+                        "type": "number",
+                        "description": "Optional: Duration in seconds for continuous publishing. Must be used with frequency parameter.",
+                    },
                 },
                 "required": ["topic_name", "message_type", "data"],
             },
@@ -377,9 +386,17 @@ class ROS2TopicPublish(toolhandler.ToolHandler):
         topic_name = args.get("topic_name")
         message_type = args.get("message_type")
         data = args.get("data")
+        frequency = args.get("frequency")
+        duration = args.get("duration")
 
         ros = get_ros()
-        publish_to_topic = ros.publish_to_topic(topic_name, message_type, data)
+        publish_to_topic = ros.publish_to_topic(
+            topic_name, 
+            message_type, 
+            data,
+            frequency=frequency,
+            duration=duration
+        )
         return [TextContent(type="text", text=json.dumps(publish_to_topic, indent=2))]
 
 class ROS2ListActions(toolhandler.ToolHandler):


### PR DESCRIPTION
This pull request adds support for publishing ROS 2 messages to a topic at a specified frequency for a given duration, in addition to the existing single-message publish functionality. The changes update both the backend logic and the tool interface to handle these new parameters.

**Continuous message publishing support:**

* [`server/ros2_manager.py`](diffhunk://#diff-a08d324a09cc9283f6e923154eec2512fa9ecdf5e6a59bf53005849b41a0ae08L542-R549): The `publish_to_topic` method now accepts optional `frequency` and `duration` parameters, allowing messages to be published repeatedly at a set rate for a specified time. Input validation ensures both values are positive, and the method returns the count of published messages when used. [[1]](diffhunk://#diff-a08d324a09cc9283f6e923154eec2512fa9ecdf5e6a59bf53005849b41a0ae08L542-R549) [[2]](diffhunk://#diff-a08d324a09cc9283f6e923154eec2512fa9ecdf5e6a59bf53005849b41a0ae08R588-R616)

**Tool interface updates:**

* [`server/tools_ros2.py`](diffhunk://#diff-34b6d7ccbf497a588bb98eb238ffcf6b234715e631914f88ceab429818ec9882R353): The tool description and input schema are updated to document the new `frequency` and `duration` options, clarifying how to use continuous publishing. [[1]](diffhunk://#diff-34b6d7ccbf497a588bb98eb238ffcf6b234715e631914f88ceab429818ec9882R353) [[2]](diffhunk://#diff-34b6d7ccbf497a588bb98eb238ffcf6b234715e631914f88ceab429818ec9882R371-R378)
* [`server/tools_ros2.py`](diffhunk://#diff-34b6d7ccbf497a588bb98eb238ffcf6b234715e631914f88ceab429818ec9882R389-R399): The `run_tool` method passes the new parameters to `publish_to_topic`, enabling the feature via the tool interface.