### PR TITLE
Update server name and repository URL in Dockerfile and server.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG ROS_DISTRO=jazzy
 FROM wisevision/ros_with_wisevision_msgs_and_wisevision_core:${ROS_DISTRO}
 
-LABEL io.modelcontextprotocol.server.name="io.github.wise-vision/mcp_server_ros_2"
+LABEL io.modelcontextprotocol.server.name="io.github.wise-vision/ros2_mcp"
 
 ENV MCP_CUSTOM_PROMPTS="false" \
     MCP_PROMPTS_LOCAL="false" \

--- a/server.json
+++ b/server.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
-  "name": "io.github.wise-vision/mcp_server_ros_2",
+  "name": "io.github.wise-vision/ros2_mcp",
   "description": "View ROS 2 nodes and topics, and call services and actions via MCP",
   "repository": {
-    "url": "https://github.com/wise-vision/mcp_server_ros_2",
+    "url": "https://github.com/wise-vision/ros2_mcp",
     "source": "github"
   },
   "version": "1.0.0",
@@ -13,7 +13,43 @@
       "identifier": "docker.io/mcp/ros2:latest",
       "transport": {
         "type": "stdio"
-      }
+      },
+      "runtimeHint": "docker",
+      "runtimeArguments": [
+        {
+          "type": "named",
+          "name": "-v",
+          "description": "Mount custom messages directory",
+          "value": "~/mcp_custom_messages:/app/custom_msgs",
+          "isRequired": false
+        }
+      ],
+      "environmentVariables": [
+        {
+          "name": "MCP_CUSTOM_PROMPTS",
+          "description": "Enable custom prompts",
+          "isRequired": false,
+          "value": "false"
+        },
+        {
+          "name": "MCP_PROMPTS_LOCAL",
+          "description": "Use local prompts",
+          "isRequired": false,
+          "value": "false"
+        },
+        {
+          "name": "MCP_PROMPTS_PATH",
+          "description": "Path to custom prompts directory",
+          "isRequired": false,
+          "value": "/app/ros2_mcp_prompts"
+        },
+        {
+          "name": "MCP_PROMPTS_MODULE",
+          "description": "Name of the prompts module",
+          "isRequired": false,
+          "value": "extension_prompts"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
This pull request updates the project to use the new name `ros2_mcp` instead of `mcp_server_ros_2`, and enhances the configuration for Docker runtime support. The most significant changes are renaming across files and adding more flexible runtime options in `server.json`.

**Project renaming:**

* Updated the server name and repository references from `mcp_server_ros_2` to `ros2_mcp` in both the `Dockerfile` and `server.json` to reflect the new project identity. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L4-R4) [[2]](diffhunk://#diff-a49a8fd223e4838c13a52213b7ed14b3c5aa03077d9d94b621b27484875be429L3-R6)

**Docker runtime configuration enhancements:**

* Added a `runtimeHint` for Docker and a `runtimeArguments` section in `server.json`, allowing users to mount a custom messages directory via the `-v` flag.
* Introduced a list of environment variables in `server.json` to enable or configure custom prompts, local prompts, prompts path, and prompts module, providing more flexibility for runtime customization.