### PR TITLE
Add support for Zenoh RMW

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y \
     python3-pip \
     build-essential \
     ca-certificates \
+    ros-${ROS_DISTRO}-rmw-zenoh-cpp \
     ros-${ROS_DISTRO}-std-msgs \
     ros-${ROS_DISTRO}-geometry-msgs \
     ros-${ROS_DISTRO}-sensor-msgs \
@@ -69,10 +70,13 @@ VOLUME ["/ros2_mcp_prompts"]
 RUN mkdir -p /mcp/custom_msgs
 VOLUME ["/mcp/custom_msgs"]
 
+ENV RMW_IMPLEMENTATION=""
+
 ENTRYPOINT []
 CMD ["bash", "-c", " \
   source /opt/ros/${ROS_DISTRO}/setup.bash && \
   source /root/wisevision_ws/install/setup.bash && \
+  if [ -n \"$RMW_IMPLEMENTATION\" ]; then export RMW_IMPLEMENTATION=$RMW_IMPLEMENTATION; fi && \
   if [ -f /app/custom_msgs/install/setup.bash ]; then \
   source /app/custom_msgs/install/setup.bash; \
   fi && \

--- a/installation/README.md
+++ b/installation/README.md
@@ -80,7 +80,7 @@ To use custom messages [create folder](#add-custom-messages) and paste it into c
 To use custom prompts:
 ```json
 {
-  "mcp_server_ros_2": {
+  "ros2_mcp": {
     "command": "docker",
     "args": [
       "run",
@@ -98,7 +98,7 @@ To use custom prompts:
 To use custom prompts from local folder:
 ```json
 {
-  "mcp_server_ros_2": {
+  "ros2_mcp": {
     "command": "docker",
     "args": [
       "run",
@@ -208,7 +208,7 @@ To use custom prompts:
 To use custom prompts from local folder:
 ```json
 {
-  "mcp_server_ros_2": {
+  "ros2_mcp": {
     "command": "docker",
     "args": [
       "run",
@@ -228,7 +228,7 @@ To use custom prompts from local folder:
 To use custom messages [create folder](#add-custom-messages) and paste it into config:
 ```json
 {
-  "mcp_server_ros_2": {
+  "ros2_mcp": {
     "command": "docker",
     "args": [
       "run",
@@ -247,6 +247,29 @@ To use custom messages [create folder](#add-custom-messages) and paste it into c
 ### Step 4: Save and Enjoy
 
 After saving you should see indicator that the MCP server is running. You can now test the setup by using the AI features in WARP.
+
+### How to use ros2 mcp with [rmw_zenoh](https://github.com/ros2/rmw_zenoh)
+
+Set the `RMW_IMPLEMENTATION` environment variable to `rmw_zenoh_cpp`:
+
+```json
+{
+  "ros2_mcp": {
+    "command": "docker",
+    "args": [
+      "run",
+      "-i",
+      "--rm",
+      "-e", "RMW_IMPLEMENTATION=rmw_zenoh_cpp",
+      "wisevision/ros2_mcp:<humble/jazzy>"
+    ],
+    "env": {},
+    "working_directory": null,
+    "start_on_launch": true
+  }
+}
+```
+
 
 # Build docker image locally:
 ```bash


### PR DESCRIPTION
This pull request updates the Docker setup and documentation to support the `rmw_zenoh_cpp` ROS middleware implementation and standardizes the configuration name for the ROS2 MCP server. The most important changes are grouped below:

**Dockerfile enhancements for middleware support:**

* Added installation of the `ros-${ROS_DISTRO}-rmw-zenoh-cpp` package to the Docker image to enable Zenoh-based ROS communication.
* Introduced an `RMW_IMPLEMENTATION` environment variable in the Dockerfile, allowing runtime selection of the ROS middleware implementation. The container startup command now exports this variable if set.

**Documentation and configuration improvements:**

* Standardized the configuration name from `mcp_server_ros_2` to `ros2_mcp` across all example JSON blocks in `installation/README.md` for consistency. [[1]](diffhunk://#diff-44000acc45c449295a0026fa7c0a186036e322db06010ed69fbd75a816a8b53dL83-R83) [[2]](diffhunk://#diff-44000acc45c449295a0026fa7c0a186036e322db06010ed69fbd75a816a8b53dL101-R101) [[3]](diffhunk://#diff-44000acc45c449295a0026fa7c0a186036e322db06010ed69fbd75a816a8b53dL211-R211) [[4]](diffhunk://#diff-44000acc45c449295a0026fa7c0a186036e322db06010ed69fbd75a816a8b53dL231-R231)
* Added a new section to the README explaining how to use the ROS2 MCP server with `rmw_zenoh`, including example configuration for setting the `RMW_IMPLEMENTATION` environment variable.