### PR TITLE
Add DDS discovery warm-up feature for container environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,15 @@ Follow the [installation guide](installation/README.md) for step-by-step instruc
 - [💻 Install in Warp](installation/README.md#configure-warp)
 - [🐳 Build Docker Image locally](installation/README.md#build-docker-image-locally)
 
+## 🧭 DDS discovery warm-up (Docker)
+
+If the first tool call returns an incomplete list of topics/services right after container start, DDS discovery may still be in progress.
+The server performs a one-time warm-up on the first tool call in container environments; tune it via:
+
+- `MCP_ROS_DISCOVERY_STABLE_SEC` (default: `1.0`)
+- `MCP_ROS_DISCOVERY_TIMEOUT_SEC` (default: `5.0`)
+- `MCP_ROS_DISCOVERY_WARMUP=false` to disable
+
 ## 💡 Want to try it in simulation?
 [Check out the Gazebo Drone Demo section](docs/DEMO_DRONE.md)
 

--- a/installation/README.md
+++ b/installation/README.md
@@ -59,6 +59,34 @@ Before you begin, ensure you have the following:
   }
 }
 ```
+### DDS discovery warm-up (Docker)
+
+If the first tool invocation returns an incomplete list of topics/services, DDS discovery may still be in progress.
+You can enable/tune a one-time warm-up on the first tool call via environment variables:
+
+- `MCP_ROS_DISCOVERY_WARMUP` (true/false; default: auto-enabled in containers)
+- `MCP_ROS_DISCOVERY_STABLE_SEC` (default: `1.0`, increase if needed)
+- `MCP_ROS_DISCOVERY_TIMEOUT_SEC` (default: `5.0`, increase if needed)
+
+Example:
+```json
+{
+  "ros2_mcp": {
+    "command": "docker",
+    "args": [
+      "run",
+      "-i",
+      "--rm",
+      "-e", "MCP_ROS_DISCOVERY_STABLE_SEC=2.0",
+      "-e", "MCP_ROS_DISCOVERY_TIMEOUT_SEC=10.0",
+      "wisevision/ros2_mcp:<humble/jazzy>"
+    ],
+    "env": {},
+    "working_directory": null,
+    "start_on_launch": true
+  }
+}
+```
 To use custom messages [create folder](#add-custom-messages) and paste it into config:
 ```json
 {

--- a/server.json
+++ b/server.json
@@ -48,6 +48,36 @@
           "description": "Name of the prompts module",
           "isRequired": false,
           "value": "extension_prompts"
+        },
+        {
+          "name": "MCP_ROS_DISCOVERY_WARMUP",
+          "description": "Warm up ROS graph on first tool call to mitigate DDS discovery timing issues (true/false; default: auto-enabled in containers)",
+          "isRequired": false,
+          "value": "true"
+        },
+        {
+          "name": "MCP_ROS_DISCOVERY_TIMEOUT_SEC",
+          "description": "Max time (seconds) to wait during discovery warm-up",
+          "isRequired": false,
+          "value": "5.0"
+        },
+        {
+          "name": "MCP_ROS_DISCOVERY_STABLE_SEC",
+          "description": "Required 'no changes' window (seconds) before proceeding during discovery warm-up",
+          "isRequired": false,
+          "value": "1.0"
+        },
+        {
+          "name": "MCP_ROS_DISCOVERY_POLL_SEC",
+          "description": "Polling interval (seconds) used during discovery warm-up",
+          "isRequired": false,
+          "value": "0.1"
+        },
+        {
+          "name": "MCP_ROS_DISCOVERY_DELAY_SEC",
+          "description": "Minimum delay (seconds) before the first tool proceeds (in addition to stability check)",
+          "isRequired": false,
+          "value": "0.0"
         }
       ]
     }

--- a/server/ros2_manager.py
+++ b/server/ros2_manager.py
@@ -12,6 +12,8 @@
 import rclpy
 from rclpy.node import Node
 import importlib
+import os
+import threading
 from typing import Any
 from rclpy.serialization import deserialize_message
 from rosidl_runtime_py import get_interfaces
@@ -57,6 +59,44 @@ GOAL_CANCEL_RET = {
     3: "ERROR_GOAL_TERMINATED",
 }
 
+_TRUE_STRINGS = {"1", "true", "yes", "on"}
+_FALSE_STRINGS = {"0", "false", "no", "off"}
+
+
+def _parse_env_bool(name: str) -> bool | None:
+    val = os.getenv(name)
+    if val is None:
+        return None
+    norm = val.strip().lower()
+    if norm in _TRUE_STRINGS:
+        return True
+    if norm in _FALSE_STRINGS:
+        return False
+    return None
+
+
+def _parse_env_float(name: str, default: float) -> float:
+    val = os.getenv(name)
+    if val is None:
+        return default
+    try:
+        return float(val)
+    except ValueError:
+        return default
+
+
+def _is_container_environment() -> bool:
+    try:
+        if os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv"):
+            return True
+
+        # Fallback for container runtimes that don't expose the marker files.
+        with open("/proc/1/cgroup", "rt", encoding="utf-8", errors="ignore") as f:
+            cgroup = f.read()
+        return any(token in cgroup for token in ("docker", "containerd", "kubepods", "podman", "libpod"))
+    except Exception:
+        return False
+
 
 class ServiceNode(Node):
     def __init__(self):
@@ -66,6 +106,101 @@ class ServiceNode(Node):
 class ROS2Manager:
     def __init__(self):
         self.node = ServiceNode()
+        self._discovery_warmed_up = False
+        self._discovery_warmup_lock = threading.Lock()
+
+    def _graph_snapshot(self) -> tuple[tuple[tuple[str, tuple[str, ...]], ...], tuple[tuple[str, tuple[str, ...]], ...]]:
+        topics = tuple(
+            sorted((name, tuple(types)) for name, types in self.node.get_topic_names_and_types())
+        )
+        services = tuple(
+            sorted((name, tuple(types)) for name, types in self.node.get_service_names_and_types())
+        )
+        return topics, services
+
+    def warm_up_discovery(self) -> dict:
+        """
+        Mitigate DDS discovery timing issues (common in containers) by waiting
+        on the first tool invocation until the ROS graph stabilizes.
+
+        Env vars:
+        - MCP_ROS_DISCOVERY_WARMUP: true/false (default: auto; enabled in containers)
+        - MCP_ROS_DISCOVERY_TIMEOUT_SEC: max wait time (default: 5.0)
+        - MCP_ROS_DISCOVERY_STABLE_SEC: required "no changes" window (default: 1.0)
+        - MCP_ROS_DISCOVERY_POLL_SEC: polling interval (default: 0.1)
+        - MCP_ROS_DISCOVERY_DELAY_SEC: minimum wait before proceeding (default: 0.0)
+        """
+        if self._discovery_warmed_up:
+            return {"status": "already_warmed"}
+
+        with self._discovery_warmup_lock:
+            if self._discovery_warmed_up:
+                return {"status": "already_warmed"}
+
+            enabled_env = _parse_env_bool("MCP_ROS_DISCOVERY_WARMUP")
+            enabled = _is_container_environment() if enabled_env is None else enabled_env
+
+            if not enabled:
+                self._discovery_warmed_up = True
+                return {"status": "disabled"}
+
+            timeout_sec = max(_parse_env_float("MCP_ROS_DISCOVERY_TIMEOUT_SEC", 5.0), 0.0)
+            stable_sec = max(_parse_env_float("MCP_ROS_DISCOVERY_STABLE_SEC", 1.0), 0.0)
+            poll_sec = max(_parse_env_float("MCP_ROS_DISCOVERY_POLL_SEC", 0.1), 0.01)
+            delay_sec = max(_parse_env_float("MCP_ROS_DISCOVERY_DELAY_SEC", 0.0), 0.0)
+
+            max_wait_sec = max(timeout_sec, delay_sec)
+            if max_wait_sec <= 0.0 and stable_sec <= 0.0:
+                self._discovery_warmed_up = True
+                return {"status": "skipped"}
+
+            start = time.monotonic()
+            last_snapshot = None
+            last_change = start
+            polls = 0
+
+            while True:
+                now = time.monotonic()
+                elapsed = now - start
+                if elapsed >= max_wait_sec:
+                    break
+
+                remaining = max_wait_sec - elapsed
+                step = min(poll_sec, remaining)
+
+                # Give rclpy a chance to process graph updates, but avoid busy looping.
+                step_start = time.monotonic()
+                try:
+                    rclpy.spin_once(self.node, timeout_sec=step)
+                except Exception:
+                    pass
+                spun = time.monotonic() - step_start
+                if spun < step:
+                    time.sleep(step - spun)
+
+                snapshot = self._graph_snapshot()
+                polls += 1
+                now = time.monotonic()
+                elapsed = now - start
+
+                if snapshot != last_snapshot:
+                    last_snapshot = snapshot
+                    last_change = now
+
+                if elapsed >= delay_sec and (now - last_change) >= stable_sec:
+                    break
+
+            self._discovery_warmed_up = True
+            elapsed_total = time.monotonic() - start
+            topics_count = len(last_snapshot[0]) if last_snapshot else 0
+            services_count = len(last_snapshot[1]) if last_snapshot else 0
+            return {
+                "status": "warmed",
+                "elapsed_sec": elapsed_total,
+                "polls": polls,
+                "topics": topics_count,
+                "services": services_count,
+            }
 
     def get_qos_profile_for_topic(self, node, topic_name: str):
 

--- a/server/tools_ros2.py
+++ b/server/tools_ros2.py
@@ -34,6 +34,7 @@ def get_ros() -> ros2_manager.ROS2Manager:
                 "rclpy is not initialized. Make sure rclpy.init() was called in main()."
             )
         _ros_instance = ros2_manager.ROS2Manager()
+    _ros_instance.warm_up_discovery()
     return _ros_instance
 
 


### PR DESCRIPTION
This pull request introduces a DDS discovery warm-up mechanism to address timing issues with topic/service discovery, especially in Docker/container environments. It adds new environment variables to control this behavior, updates documentation to explain the feature and its configuration, and implements the warm-up logic in the ROS2 manager. The goal is to ensure that the list of ROS topics and services is complete and stable before the first tool invocation.

**DDS Discovery Warm-up Feature**

- Added a DDS discovery warm-up mechanism to the `ROS2Manager` class, which waits for the ROS graph to stabilize on the first tool call, mitigating incomplete topic/service lists in containerized environments. This includes logic to detect container environments, configurable timing, and thread safety. (`server/ros2_manager.py`, `server/tools_ros2.py`) [[1]](diffhunk://#diff-a08d324a09cc9283f6e923154eec2512fa9ecdf5e6a59bf53005849b41a0ae08R62-R99) [[2]](diffhunk://#diff-a08d324a09cc9283f6e923154eec2512fa9ecdf5e6a59bf53005849b41a0ae08R109-R203) [[3]](diffhunk://#diff-34b6d7ccbf497a588bb98eb238ffcf6b234715e631914f88ceab429818ec9882R37)

- Introduced new environment variables for controlling the warm-up: `MCP_ROS_DISCOVERY_WARMUP`, `MCP_ROS_DISCOVERY_TIMEOUT_SEC`, `MCP_ROS_DISCOVERY_STABLE_SEC`, `MCP_ROS_DISCOVERY_POLL_SEC`, and `MCP_ROS_DISCOVERY_DELAY_SEC`. These are now documented and included in the server configuration. (`server.json`)

**Documentation Updates**

- Added sections to the main `README.md` and `installation/README.md` explaining the DDS discovery warm-up feature, its purpose, and how to configure it using environment variables. Includes usage examples for Docker. (`README.md`, `installation/README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R107-R115) [[2]](diffhunk://#diff-44000acc45c449295a0026fa7c0a186036e322db06010ed69fbd75a816a8b53dR62-R89)