### PR TITLE
Fix Jazzy FastRTPS type support mismatch

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -28,7 +28,15 @@ jobs:
 
       - name: Docker build (${{ matrix.ros_distro }})
         run: |
-          docker build -t ros2_mcp  --build-arg ROS_DISTRO=${{ matrix.ros_distro }} .
+          docker build -t ros2_mcp --build-arg ROS_DISTRO=${{ matrix.ros_distro }} .
+
+      - name: ROS 2 type support smoke test (${{ matrix.ros_distro }})
+        run: |
+          docker run --rm --entrypoint bash ros2_mcp -lc '
+            source /opt/ros/${{ matrix.ros_distro }}/setup.bash
+            source /root/wisevision_ws/install/setup.bash
+            /app/.venv/bin/python3 -c "from builtin_interfaces.msg import Time; from rclpy.serialization import serialize_message; Time.__import_type_support__(); serialize_message(Time(sec=1, nanosec=2)); print(\"ROS 2 type support smoke test passed\")"
+          '
 
   build_and_push_arm64:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,11 @@ ENV MCP_CUSTOM_PROMPTS="false" \
     MCP_PROMPTS_PATH="/app/ros2_mcp_prompts" \
     MCP_PROMPTS_MODULE="extension_prompts"
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && \
+    if [ "$ROS_DISTRO" = "jazzy" ]; then \
+        apt-get upgrade -y ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-cpp; \
+    fi && \
+    apt-get install -y \
     python3-pip \
     build-essential \
     ca-certificates \


### PR DESCRIPTION
## Summary
- Fixes the Jazzy Docker image ABI mismatch reported in #46 by refreshing the Jazzy ROS/FastRTPS type-support stack before installing additional dependencies.
- Adds a Docker runtime smoke test to PR CI so a build-only pass cannot hide this failure again.

## Why
Issue #46 reproduces as:

```text
/app/.venv/bin/python3: symbol lookup error:
/opt/ros/jazzy/lib/libbuiltin_interfaces__rosidl_typesupport_fastrtps_c.so:
undefined symbol: _ZN8eprosima7fastcdr3Cdr9serializeEj
```

The base image had newer `builtin_interfaces` packages but stale Fast CDR/FastRTPS type-support packages. Updating the Jazzy ROS package set before the regular install aligns those ABI-sensitive packages.

## Verification
Locally reproduced the failure on current `main`, then verified this branch:

```bash
docker build --pull -t ros2-mcp-issue46-pr --build-arg ROS_DISTRO=jazzy .
docker run --rm --entrypoint bash ros2-mcp-issue46-pr -lc '
  source /opt/ros/jazzy/setup.bash
  source /root/wisevision_ws/install/setup.bash
  /app/.venv/bin/python3 -c "from builtin_interfaces.msg import Time; from rclpy.serialization import serialize_message; Time.__import_type_support__(); serialize_message(Time(sec=1, nanosec=2)); print(\"ROS 2 type support smoke test passed\")"
'
```

Result:

```text
ROS 2 type support smoke test passed
```

## Deploy wiring
`docker_image.yml` already builds Docker images on PR. On merge/push to `main`, it builds and pushes `humble` and `jazzy` multi-arch Docker Hub images, then sends the repository dispatch to `wise-vision/mcp_server_ros_2-private`.

Closes #46
