### PR TITLE
fix(ci): use PAT_TOKEN for main->dev sync (workflow-file syncs were silently failing)

### DIFF
--- a/.github/workflows/sync_main_to_dev.yml
+++ b/.github/workflows/sync_main_to_dev.yml
@@ -17,9 +17,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5     
-        with: 
-          fetch-depth: 0 
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          # The default GITHUB_TOKEN cannot push changes that touch
+          # .github/workflows/* (GitHub refuses workflow-file writes from the
+          # Actions token — there is no permissions: scope that grants it).
+          # A main->dev sync that carries a workflow change is therefore
+          # rejected. Persist a PAT with `workflow` scope so the push succeeds.
+          token: ${{ secrets.PAT_TOKEN }}
 
       - name: Set up Git
         run: |


### PR DESCRIPTION
The default `GITHUB_TOKEN` cannot push commits that touch `.github/workflows/*` — GitHub refuses workflow-file writes from the Actions token, and no `permissions:` scope grants it. So any main->dev sync that carries a workflow change is rejected and `dev` silently falls behind `main`.

**This just happened for real:** merging #50 (the CI-hosting migration, entirely workflow-file changes) fired Sync Main to Dev, which failed with:
```
! [remote rejected] dev -> dev (refusing to allow a GitHub App to create or
update workflow .github/workflows/server_tests.yml without workflows permission)
```

**Fix:** persist `secrets.PAT_TOKEN` (already in the repo, used by `docker_image.yml` send_trigger) in the sync checkout so the push authenticates as a user with `workflow` scope.

`dev` was manually resynced via SSH this session to unblock #48; the next automatic sync will exercise this path.

Opened by the repo autopilot (supervised).