### PR TITLE
ci: add tag-triggered release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release
+
+# Cut a GitHub Release automatically when a version tag is pushed.
+#
+# Convention (matches historical scheme: YYMM, e.g. 2606 = June 2026):
+#   git tag 2606 <commit>
+#   git push origin 2606
+#
+# Pushing a tag matching the pattern below creates the GitHub Release and
+# auto-generates notes from the commits since the previous tag. Tag creation
+# is the manual gate — nothing releases until a maintainer pushes the tag.
+
+on:
+  push:
+    tags:
+      - '[0-9][0-9][0-9][0-9]'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists — nothing to do."
+            exit 0
+          fi
+          gh release create "$TAG" \
+            --title "Release $TAG" \
+            --target "$GITHUB_SHA" \
+            --generate-notes


### PR DESCRIPTION
## Problem

The repo has no release automation. "Release NNNN" PRs merge to main, but the actual GitHub Release + tag were always cut by hand. Release 2606 (PR #48) merged 2026-07-13 but no tag/release was ever created — the Releases page still showed 2511 as latest.

## Fix

Adds `.github/workflows/release.yml`. Pushing a version tag matching the historical date scheme (`NNNN`, e.g. `2606` = June 2026) auto-creates the GitHub Release with auto-generated notes from commits since the previous tag.

**Tag creation stays the manual gate** — nothing releases until a maintainer pushes the tag:

```
git tag 2607 <commit>
git push origin 2607
```

Idempotent: if a release for the tag already exists, the workflow no-ops (so the manually-cut 2606 won't conflict if re-tagged).

## Notes
- Release 2606 was cut manually to unblock; this workflow prevents recurrence.
- Uses the built-in `github.token` — no PAT needed for release creation.